### PR TITLE
Add User-Agent headers for image requests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bin/
 share/
 include/
 results/
+result/

--- a/image_search.py
+++ b/image_search.py
@@ -26,11 +26,14 @@ def get_search_results(search_term):
 
 
 def write_image(image_url, download_dir):
+    headers = {
+        "User-Agent": 'Mozilla/5.0 (X11; Linux x86_64; rv:61.0) Gecko/20100101 Firefox/61.0'
+    }
     parsed_url = urlparse(image_url)
     name, ext = Path(parsed_url.path).name.split('.')
     name = name[:20]
 
-    response = requests.get(image_url)
+    response = requests.get(image_url, headers=headers)
     response.raise_for_status()
 
     output_image = download_dir.child('{}.{}'.format(name, ext))


### PR DESCRIPTION
This PR avoids errors on image requests in CDNs.
We are using a Firefox browser User-Agent as value for those requests.

![image](https://user-images.githubusercontent.com/418606/44119464-a803f2a6-9fef-11e8-83af-4adce223cc7a.png)
